### PR TITLE
F/2080/client secret

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,76 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.79.0"
+  hashes = [
+    "h1:0R7P7/ezHdqLHRsBoIA+jfI8f73mah7r41T9Xgp2bpw=",
+    "h1:Uysey/4F8JQba8ABH+FyvcIhK22jEq6mdnaqjRNcXcw=",
+    "h1:VIIcae7BNc1eYKWb5WsZ+QKpFHbDN1kBdfgRRRtiIIY=",
+    "h1:jWOG+JhHLmfd20Zj/kve97+1e2eBwU8lETOVYnR08Ew=",
+    "h1:tWd63H8jMJHdsuwg3hkviz/b8OyL/gBogmXRA5kYb9A=",
+    "zh:008b605b7b6dcde4eb86759f54a36db731f94649f780738c6918ef3826eb064f",
+    "zh:08c1dd9a2b4b0d45356fc2124ac292aa549aab9053e33e240dd322700082c132",
+    "zh:0fa102804fc3903a598b631a791c40fd285162738c2939e92980078bb5c58bf8",
+    "zh:217f19d86f51e89ef479aa6b08ad3205c9ffe1d60422bbe10b373232658c56c2",
+    "zh:5ebf88b696c15dcd5e9a8ec3e7c58ecc6c1939bc75b72710bb8454c8a59dabce",
+    "zh:77da434b802735cdac2c5f4cd28b18a8221de4ec443019d4e17beab0aa064b09",
+    "zh:7a3cdb0f3dbc0cc6e50e3e719c48513d73a23acc154c2a6fa3a501cc86f02831",
+    "zh:878dc6b3c5d3068f439f1617051f3d2da9b899741fcc66d98a46a8bacf4fb320",
+    "zh:940ead03bdf6401ed921b71a6e14edbb613fd1f0eefc41bf555bc3d499cc604e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a3b496cf3a537a1b74e1433c7a4c5b19d51ed7c094c640dd240e474886b8c1de",
+    "zh:baac56fafa9d4aa6102554c9c6ca340512c18a31bf0c9899f7e0e823bb18a32a",
+    "zh:e1560da6a1cb052f719199f20f0238d4fab606f54f3ddad1b09ad390ab5c4a46",
+    "zh:e3fb0ad64e1812f4560396c2660e729c760ecb593f3fd1b0d76101d6923e8230",
+    "zh:fdc5159df807242e884b108746ac4ddf9725b7ce9f425785d4af465845de280e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.3"
+  hashes = [
+    "h1:+UItZOLue/moJfnI3tqZBQbXUYR4ZnqPYfJDJPgLZy0=",
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
+    "h1:In4XBRMdhY89yUoTUyar3wDF28RJlDpQzdjahp59FAk=",
+    "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}
+
+provider "registry.terraform.io/nullstone-io/ns" {
+  version = "0.6.24"
+  hashes = [
+    "h1:ORFNEXgv7Pvt8sBS51xL1/ZNYMnAHUo+jRXbz02CRdM=",
+    "h1:XizFYcjQm2TE+uPfv2XGlJteYVMJr22SjkMZb13mCPE=",
+    "h1:ipu82tc68+Mv147lqIEUNzKwGovK7wxnkruPy6X28vU=",
+    "h1:j8PUFGXZmsmYsUaWDVa4AhEfkselQKGJe/lEBsIbxhM=",
+    "h1:vgcMQsOCNtc9AgUSv1CYuslAxfA931o4qp4egsSde8M=",
+    "zh:0afca196adbfcec7dc76edc2307789c518f6bee47eabd5478e0ec76e92e5686c",
+    "zh:19c6bdf2f5e9d478420afc88fe0a77750d78481bb9a7466c09e3c8c0df168eb3",
+    "zh:38ea4dde252b6b232132d8bd5e8b9c9be65aabdb813f999403eeff043bab0d77",
+    "zh:3e1467b17bc72b62286a8fb6416d8448f32a1c0c5d562b5f0d9ee65e87e61772",
+    "zh:49ceac32a976ba8288d0861bc06be0c934a8cb321c5b6c9e2aba01f743d6a89c",
+    "zh:5050ecd840577990a769d2d6a1175fe21fba8a9698b0444fe18b5f5ce4a5bbf7",
+    "zh:64752162f4aaf58ee078ec66ce05458ee800152839221adb966650d1cdcfbb78",
+    "zh:7624c5ab46b0b05669e203629d6d8a159da64c3bc1084971bba29cf57c919e1c",
+    "zh:90ec9f7501567840298636254eb9a1f2698bf6e3cdc0bed6d880bca2193183d0",
+    "zh:b63aaebc716190f58981e7de7469409e2795612b63d79813e6c7285f9bd7a942",
+    "zh:cd0e6ceaacd6f015892be49d60a66e235b8b4b7fad31ce17228c8978a5bb432f",
+    "zh:d6371972cd5c544ad2203ec9199dd044984e33d73efb52020c617dae84c75131",
+    "zh:f7d79b7c05d6da017a7d999ec34d494d96d2f8513f0aefc794b243494111ba5b",
+    "zh:fe5b68873f10aa3beda063528a4767117925d713302a2bed8529de886c1a11bd",
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+lock-providers:
+	terraform providers lock -platform=linux_amd64 -platform=linux_arm64 -platform=darwin_amd64 -platform=darwin_arm64 -platform=windows_amd64

--- a/app_client.tf
+++ b/app_client.tf
@@ -1,0 +1,8 @@
+data "aws_cognito_user_pool_client" "this" {
+  user_pool_id = var.user_pool_id
+  client_id    = var.client_id
+}
+
+locals {
+  client_secret = data.aws_cognito_user_pool_client.this.client_secret
+}

--- a/client_secret.tf
+++ b/client_secret.tf
@@ -1,0 +1,9 @@
+resource "aws_secretsmanager_secret" "client_secret" {
+  name = "${local.resource_name}/client_secret"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "client_secret" {
+  secret_id     = aws_secretsmanager_secret.client_secret.id
+  secret_string = local.client_secret
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,12 +13,17 @@ output "identity_pool_id" {
   description = "string ||| The id of the identity pool."
 }
 
+output "client_secret_secret_id" {
+  value       = aws_secretsmanager_secret.client_secret.id
+  description = "string ||| The secret id for the AWS secrets manager secret that contains the client_secret for the cognito user pool."
+}
+
 output "access_key_id_secret_id" {
   value       = aws_secretsmanager_secret.access_key_id.id
-  description = "string || The secret id for the the access key id to be used to access this user pool."
+  description = "string ||| The secret id for the AWS secrets manager secret that contains the access key id for the cognito user pool."
 }
 
 output "secret_access_key_secret_id" {
   value       = aws_secretsmanager_secret.secret_access_key.id
-  description = "string || The secret id for the secret access key to be used to access this user pool."
+  description = "string ||| The secret id for the AWS secrets manager secret for the secret access key for the cognito user pool."
 }


### PR DESCRIPTION
This adds `client_secret` from the cognito user pool client to an AWS secrets manager secret.
The id of this secret is emitted as an output `client_secret_secret_id`.

This will be used by capabilities to inject into the client_secret into apps.