### PR TITLE
B2123 fix missing client_secret

### DIFF
--- a/client_secret.tf
+++ b/client_secret.tf
@@ -1,9 +1,13 @@
 resource "aws_secretsmanager_secret" "client_secret" {
+  count = var.client_secret != "" ? 1 : 0
+
   name = "${local.resource_name}/client_secret"
   tags = local.tags
 }
 
 resource "aws_secretsmanager_secret_version" "client_secret" {
+  count         = var.client_secret != "" ? 1 : 0
+
   secret_id     = aws_secretsmanager_secret.client_secret.id
   secret_string = var.client_secret
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "identity_pool_id" {
 }
 
 output "client_secret_secret_id" {
-  value       = var.client_secret != "" ? aws_secretsmanager_secret.client_secret.id : ""
+  value       = var.client_secret != "" ? aws_secretsmanager_secret.client_secret[0].id : ""
   description = "string ||| The secret id for the AWS secrets manager secret that contains the client_secret for the cognito user pool. Will return an empty string if the parameter is not provided in the inputs."
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,8 +14,8 @@ output "identity_pool_id" {
 }
 
 output "client_secret_secret_id" {
-  value       = aws_secretsmanager_secret.client_secret.id
-  description = "string ||| The secret id for the AWS secrets manager secret that contains the client_secret for the cognito user pool."
+  value       = var.client_secret != "" ? aws_secretsmanager_secret.client_secret.id : ""
+  description = "string ||| The secret id for the AWS secrets manager secret that contains the client_secret for the cognito user pool. Will return an empty string if the parameter is not provided in the inputs."
 }
 
 output "access_key_id_secret_id" {


### PR DESCRIPTION
This PR fixes an error that occurs using this module if you don't provide a `client_secret` value as a parameter.

The module is unable to create the secret in secrets manager because there is no value. This change just skips the creation and outputs a blank string for the `client_secret_secret_id` output in this scenario.
